### PR TITLE
Check existence of _data attribute on context

### DIFF
--- a/lektor_jinja_content.py
+++ b/lektor_jinja_content.py
@@ -43,7 +43,8 @@ class JinjaContentPlugin(Plugin):
         return blocks
 
     def on_process_template_context(self, context, **extra):
-        if not extra["template"]:  # Only be triggered by page evaluation.
+        # Only be triggered by page evaluation with _data attibute.
+        if not extra["template"] or not hasattr(context["this"], "_data"):
             return
 
         for field in context["this"]._data.keys():


### PR DESCRIPTION
Not all the contexts have a _data attribute, which makes the build fail when trying to access it.

This happened when I tried to build a project that includes [lektor-tags (v0.1)](https://pypi.org/project/lektor-tags/) (which, coincidentally, I just discovered you're a maintainer :))

The errors are:
```
U blog/tag/bitcoin/index.html
E blog/tag/bitcoin/index.html (AttributeError: 'TagPage' object has no attribute '_data')
U blog/tag/cloud/index.html
E blog/tag/cloud/index.html (AttributeError: 'TagPage' object has no attribute '_data')
...
```