### PR TITLE
potential fix for issue #13

### DIFF
--- a/lektor_jinja_content.py
+++ b/lektor_jinja_content.py
@@ -54,6 +54,9 @@ class JinjaContentPlugin(Plugin):
                     context, context["this"]._data[field]._blocks
                 )
             else:
-                context["this"]._data[field] = self.process_field(
-                    context, context["this"]._data[field]
-                )
+                if field_val:
+                    context["this"]._data[field] = self.process_field(
+                        context, context["this"]._data[field]
+                    )
+                else:
+                    return ''

--- a/tests/demo-project/content/test_undefined/contents.lr
+++ b/tests/demo-project/content/test_undefined/contents.lr
@@ -1,0 +1,3 @@
+_model: test_undefined
+---
+body: foo

--- a/tests/demo-project/models/test_undefined.ini
+++ b/tests/demo-project/models/test_undefined.ini
@@ -1,0 +1,15 @@
+[model]
+name = Page
+label = {{ this.title }}
+
+[fields.title]
+label = Title
+type = string
+
+[fields.meta_title]
+label = MetaData Title
+type = string
+
+[fields.body]
+label = Body
+type = string

--- a/tests/demo-project/templates/test_undefined.html
+++ b/tests/demo-project/templates/test_undefined.html
@@ -1,0 +1,6 @@
+test_undefined
+{% extends "test_undefined_layout.html" %}
+{% block meta_title %}{{ this.meta_title or this.title }}{% endblock %}
+{% block body %}
+  {{ this.body }}
+{% endblock %}

--- a/tests/demo-project/templates/test_undefined_layout.html
+++ b/tests/demo-project/templates/test_undefined_layout.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    test_undefined_layout
+    <title>{% block title %}TITLE{% endblock %}</title>
+    <meta name="title" content="{% block meta_title %}{% endblock %}"/>
+</head>
+<body>
+{% block body %}{% endblock %}
+</body>
+</html>


### PR DESCRIPTION
This is a potential fix for issue #13 along with a test case that does not raise an error on building the page (i'm not sure how to otherwise test)

The issue seemed to be an empty field being passed into `process_field`/`render_as_jinja`, which then triggered a `jinja2.runtime.Undefined` exception for the field.  The package otherwise tests for a `jinja2.exceptions.UndefinedError` which is raised in other contexts.

I am not extremely familiar with jinja2/lektor so I am not sure if this approach will break more things than it fixes. It does not seem to though.